### PR TITLE
Enable to accept multi-byte search query.

### DIFF
--- a/menu-bar-search/main.rb
+++ b/menu-bar-search/main.rb
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 load 'menu_items.rb'
 
-search_term = ARGV[0].nil? ? "" : ARGV[0].downcase
+search_term = ARGV[0].nil? ? "" : ARGV[0].downcase.encode('utf-8', 'utf-8-mac')
 
 if (search_term.length > 1)
 	puts MenuItems.generate_xml(search_term, MenuItems.generate_items())


### PR DESCRIPTION
Menu Bar Search can't use multi-byte characters for search query by a encoding issue (e.g. Japanese).
