### PR TITLE
Fix non-latin query

### DIFF
--- a/google-autocomplete/main.rb
+++ b/google-autocomplete/main.rb
@@ -37,17 +37,18 @@ if xml_data.length > 0
 	   text = ele.elements['suggestion'].attributes['data']
      num_queries_elem = ele.elements['num_queries']
 	   count = num_queries_elem ? ele.elements['num_queries'].attributes['int'] : 0
-	   suggestions << {:text => text, :count => count}
+	   suggestions << {:text => text.encode('utf-8'), :count => count}
 	end
 end
 
-if suggestions.length == 0 || suggestions[0][:text].downcase != ARGV[0].downcase
-  suggestions.unshift({:text => ARGV[0], :count => "none"})
+user_input = ARGV[0].dup.force_encoding('utf-8')
+if suggestions.length == 0 || suggestions[0][:text].downcase != user_input.downcase
+  suggestions.unshift({:text => user_input, :count => 0})
 end
 
 feedback = Feedback.new
 suggestions.each do |suggestion|
-  count_str = suggestion[:count] == "none" ? "" : " (#{suggestion[:count]})"
+  count_str = suggestion[:count] == 0 ? "" : " (#{suggestion[:count]})"
   feedback.add_item({:uid => "suggest #{term}", :title => suggestion[:text], :subtitle => "Search Google for '#{suggestion[:text]}'#{count_str}", :arg => suggestion[:text]})
 end
 


### PR DESCRIPTION
Fix suggest for non-latin query:

```
[ERROR: alfred.workflow.input.scriptfilter] Code 1: /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rexml/text.rb:132:in `=~': incompatible encoding regexp match (UTF-8 regexp with ASCII-8BIT string) (Encoding::CompatibilityError)
	from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rexml/text.rb:132:in `!~'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rexml/text.rb:132:in `check'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rexml/attribute.rb:153:in `element='
	from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rexml/element.rb:1103:in `[]='
	from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rexml/element.rb:613:in `block in add_attributes'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rexml/element.rb:613:in `each_pair'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rexml/element.rb:613:in `add_attributes'
	from alfred_feedback.rb:32:in `block in to_xml'
	from alfred_feedback.rb:30:in `each'
	from alfred_feedback.rb:30:in `to_xml'
	from main.rb:54:in `<main>'
```